### PR TITLE
servicemp3: ignore processing of the same tags messages

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -1777,6 +1777,12 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 			result = gst_tag_list_merge(m_stream_tags, tags, GST_TAG_MERGE_REPLACE);
 			if (result)
 			{
+				if (m_stream_tags && gst_tag_list_is_equal(m_stream_tags, result))
+				{
+					gst_tag_list_free(tags);
+					gst_tag_list_free(result);
+					break;
+				}
 				if (m_stream_tags)
 					gst_tag_list_free(m_stream_tags);
 				m_stream_tags = result;


### PR DESCRIPTION
Handling of every tags message creates evUpdatedInfo event,
even if we are dealing with the same tags messages

In gstreamer-1.6.0 this becomes problem, since we are
flooded with many of the same tags messages
many tags messages -> many evUpdateInfo events ->
 -> negative impact on enigma2 performance (spinners)

To fix this we check if merged stored tags message
(m_stream_tags) with new tags message is different
then stored tags message. If it's not then we don't
create evUpdatedInfo, since nothing is changed.

Signed-off-by: Erik Slagter <erik@openpli.org>