### PR TITLE
epgcache: Allow Python threads to run while searching EPG text

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -3202,6 +3202,7 @@ PyObject *eEPGCache::search(ePyObject arg)
 							eDebug("[EPGC] lookup events, title starting with '%s' (%s)", str, casetype?"ignore case":"case sensitive");
 							break;
 					}
+					Py_BEGIN_ALLOW_THREADS; /* No Python code in this section, so other threads can run */
 					singleLock s(cache_lock);
 					std::string title;
 					for (descriptorMap::iterator it(eventData::descriptors.begin());
@@ -3261,6 +3262,7 @@ PyObject *eEPGCache::search(ePyObject arg)
 							}
 						}
 					}
+					Py_END_ALLOW_THREADS;
 				}
 				else
 				{


### PR DESCRIPTION
Another attempt at improving the GUI responsiveness while EPG searching
is in progress.

The autotimer always calls the search method from within the main GUI
thread, so it won't help there.