### PR TITLE
Drop support for DVB_API version 1, and properly check version

### DIFF
--- a/lib/dvb/volume.cpp
+++ b/lib/dvb/volume.cpp
@@ -6,7 +6,8 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-#if HAVE_DVB_API_VERSION < 3
+#include <linux/dvb/version.h>
+#if DVB_API_VERSION < 3
 #define VIDEO_DEV "/dev/dvb/card0/video0"
 #define AUDIO_DEV "/dev/dvb/card0/audio0"
 #include <ost/audio.h>
@@ -145,7 +146,7 @@ void eDVBVolumecontrol::setVolume(int left, int right)
 	int fd = openMixer();
 	if (fd >= 0)
 	{
-#ifdef HAVE_DVB_API_VERSION
+#ifdef DVB_API_VERSION
 		ioctl(fd, AUDIO_SET_MIXER, &mixer);
 #endif
 		closeMixer(fd);
@@ -177,7 +178,7 @@ void eDVBVolumecontrol::volumeMute()
 	int fd = openMixer();
 	if (fd >= 0)
 	{
-#ifdef HAVE_DVB_API_VERSION
+#ifdef DVB_API_VERSION
 		ioctl(fd, AUDIO_SET_MUTE, true);
 #endif
 		closeMixer(fd);
@@ -198,7 +199,7 @@ void eDVBVolumecontrol::volumeUnMute()
 	int fd = openMixer();
 	if (fd >= 0)
 	{
-#ifdef HAVE_DVB_API_VERSION
+#ifdef DVB_API_VERSION
 		ioctl(fd, AUDIO_SET_MUTE, false);
 #endif
 		closeMixer(fd);

--- a/m4/tuxbox.m4
+++ b/m4/tuxbox.m4
@@ -7,30 +7,5 @@ if test "$DVBINCLUDES"; then
 	CPPFLAGS="$CPPFLAGS -I$DVBINCLUDES"
 fi
 
-AC_CHECK_HEADERS(ost/dmx.h,[
-	DVB_API_VERSION=1
-	AC_MSG_NOTICE([found dvb version 1])
-])
-
-if test -z "$DVB_API_VERSION"; then
-AC_CHECK_HEADERS(linux/dvb/version.h,[
-	AC_LANG_PREPROC_REQUIRE()
-	AC_REQUIRE([AC_PROG_EGREP])
-	AC_LANG_CONFTEST([AC_LANG_SOURCE([[
-#include <linux/dvb/version.h>
-version DVB_API_VERSION
-	]])])
-	DVB_API_VERSION=`(eval "$ac_cpp conftest.$ac_ext") 2>&AS_MESSAGE_LOG_FD | $EGREP "^version" | sed "s,version\ ,,"`
-	rm -f conftest*
-
-	AC_MSG_NOTICE([found dvb version $DVB_API_VERSION])
-])
-fi
-
-if test "$DVB_API_VERSION"; then
-	AC_DEFINE(HAVE_DVB,1,[Define to 1 if you have the dvb includes])
-	AC_DEFINE_UNQUOTED(HAVE_DVB_API_VERSION,$DVB_API_VERSION,[Define to the version of the dvb api])
-else
-	AC_MSG_ERROR([can't find dvb headers])
-fi
+AC_CHECK_HEADERS_ONCE(linux/dvb/version.h)
 ])


### PR DESCRIPTION
E2 won't work with v1 anyway, so make that explicit. Also fixes the failure
to detect the version in the configure stage. Just include the version
header and detect it there, instead of relying on autotools.

This fixes E2 failure to compile with recent OE versions (GCC 5.2).