### PR TITLE
hide services again from DreamBoxEdit

### DIFF
--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -375,7 +375,6 @@ void eDVBDB::parseServiceData(ePtr<eDVBService> s, std::string str)
 		else if (p == 'f')
 		{
 			sscanf(v.c_str(), "%x", &s->m_flags);
-			s->m_flags &= ~eDVBService::dxDontshow;
 		} else if (p == 'c')
 		{
 			int cid, val;


### PR DESCRIPTION
In principle it is just to test, the user aguilarmercader in lonasdigital.com reported that it was no longer possible to hide services in DreamBoxEdit.