### PR TITLE
* ServiceMP3: Optimize GStreamer start sequence Part 2 thx athoik

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -660,8 +660,7 @@ eServiceMP3::~eServiceMP3()
 		gst_object_unref(bus);
 	}
 
-	if (m_state == stRunning)
-		stop();
+	stop();
 
 	if (m_stream_tags)
 		gst_tag_list_free(m_stream_tags);
@@ -742,12 +741,28 @@ RESULT eServiceMP3::start()
 {
 	ASSERT(m_state == stIdle);
 
-	m_state = stRunning;
 	m_subtitles_paused = false;
 	if (m_gst_playbin)
 	{
 		// eDebug("eServiceMP3::starting pipeline");
-		gst_element_set_state (m_gst_playbin, GST_STATE_PAUSED);
+		GstStateChangeReturn ret;
+		ret = gst_element_set_state (m_gst_playbin, GST_STATE_PLAYING);
+ 
+		switch(ret)
+		{
+		case GST_STATE_CHANGE_FAILURE:
+			eDebug("[eServiceMP3] failed to start pipeline");
+			stop();
+			break;
+		case GST_STATE_CHANGE_SUCCESS:
+			m_is_live = false;
+			break;
+		case GST_STATE_CHANGE_NO_PREROLL:
+			m_is_live = true;
+			break;
+		default:
+			break;
+		}
 	}
 
 	return 0;
@@ -762,26 +777,24 @@ void eServiceMP3::sourceTimeout()
 
 RESULT eServiceMP3::stop()
 {
-	ASSERT(m_state != stIdle);
-
-	if (m_state == stStopped)
+	if (!m_gst_playbin || m_state == stStopped)
 		return -1;
 
 	eDebug("eServiceMP3::stop %s", m_ref.path.c_str());
 	m_state = stStopped;
-	
-       GstStateChangeReturn ret;
-       GstState state, pending;
-       /* make sure that last state change was successfull */
-       ret = gst_element_get_state(m_gst_playbin, &state, &pending, GST_CLOCK_TIME_NONE);
-       eDebug("[eServiceMP3] stop state:%s pending:%s ret:%s",
-               gst_element_state_get_name(state),
-               gst_element_state_get_name(pending),
-               gst_element_state_change_return_get_name(ret));
 
-       ret = gst_element_set_state(m_gst_playbin, GST_STATE_NULL);
-       if (ret != GST_STATE_CHANGE_SUCCESS)
-               eDebug("[eServiceMP3] stop GST_STATE_NULL failure");
+	GstStateChangeReturn ret;
+	GstState state, pending;
+	/* make sure that last state change was successfull */
+	ret = gst_element_get_state(m_gst_playbin, &state, &pending, 5 * GST_SECOND);
+	eDebug("[eServiceMP3] stop state:%s pending:%s ret:%s",
+		gst_element_state_get_name(state),
+		gst_element_state_get_name(pending),
+		gst_element_state_change_return_get_name(ret));
+
+	ret = gst_element_set_state(m_gst_playbin, GST_STATE_NULL);
+	if (ret != GST_STATE_CHANGE_SUCCESS)
+		eDebug("[eServiceMP3] stop GST_STATE_NULL failure");
 
 	saveCuesheet();
 	m_subtitles_paused = false;
@@ -838,7 +851,6 @@ RESULT eServiceMP3::unpause()
 
 	m_subtitles_paused = false;
 	m_subtitle_sync_timer->start(1, true);
-	
 	/* no need to unpase if we are not paused already */
 	if (m_currentTrickRatio == 1.0 && !m_paused)
 	{
@@ -861,10 +873,7 @@ RESULT eServiceMP3::seek(ePtr<iSeekableService> &ptr)
 
 RESULT eServiceMP3::getLength(pts_t &pts)
 {
-	if (!m_gst_playbin)
-		return -1;
-
-	if (m_state != stRunning)
+	if (!m_gst_playbin || m_state != stRunning)
 		return -1;
 
 	GstFormat fmt = GST_FORMAT_TIME;
@@ -1055,9 +1064,7 @@ RESULT eServiceMP3::getPlayPosition(pts_t &pts)
 	gint64 pos;
 	pts = 0;
 
-	if (!m_gst_playbin)
-		return -1;
-	if (m_state != stRunning)
+	if (!m_gst_playbin || m_state != stRunning)
 		return -1;
 
 	if (audioSink || videoSink)
@@ -1094,9 +1101,7 @@ RESULT eServiceMP3::isCurrentlySeekable()
 {
 	int ret = 3; /* just assume that seeking and fast/slow winding are possible */
 
-	if (!m_gst_playbin)
-		return 0;
-	if (m_state != stRunning)
+	if (!m_gst_playbin || m_state != stRunning)
 		return 0;
 
 	return ret;
@@ -1664,7 +1669,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 				}	break;
 				case GST_STATE_CHANGE_READY_TO_PAUSED:
 				{
-					gst_element_set_state (m_gst_playbin, GST_STATE_PLAYING);
+					m_state = stRunning;
 #if GST_VERSION_MAJOR >= 1
 					GValue result = { 0, };
 #endif
@@ -1729,7 +1734,11 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 #endif
 					gst_iterator_free(children);
 
-					m_is_live = (gst_element_get_state(m_gst_playbin, NULL, NULL, 0LL) == GST_STATE_CHANGE_NO_PREROLL);
+					/* if we are in preroll already do not check again the state */
+					if (!m_is_live)
+					{
+						m_is_live = (gst_element_get_state(m_gst_playbin, NULL, NULL, 0LL) == GST_STATE_CHANGE_NO_PREROLL);
+					}
 
 					setAC3Delay(ac3_delay);
 					setPCMDelay(pcm_delay);
@@ -2087,7 +2096,7 @@ void eServiceMP3::gstBusCall(GstMessage *msg)
 			break;
 		}
 		case GST_MESSAGE_BUFFERING:
-			if (m_state == stRunning && m_sourceinfo.is_streaming)
+			if (m_sourceinfo.is_streaming)
 			{
 				GstBufferingMode mode;
 				gst_message_parse_buffering(msg, &(m_bufferInfo.bufferPercent));


### PR DESCRIPTION
On start set PLAYING state and check return value of the change state.
On stop make sure that last change state was sucessfull, it prevents deadlock on fast channel zap.
When unpause is called make sure that we are in paused state before change state.
Move evStart event in NULL to READY state and update EPG on READY to PAUSED state.

Note: The get state on stop might block forever, so use 5 seconds timeout.
Note:  The m_state change to running when pipeline is prerolled, on ready to paused state.