### PR TITLE
framebuffer: cosmetic updates

### DIFF
--- a/lib/gdi/fb.cpp
+++ b/lib/gdi/fb.cpp
@@ -65,14 +65,14 @@ fbClass::fbClass(const char *fb)
 	available=fix.smem_len;
 	m_phys_mem = fix.smem_start;
 #if defined(__sh__)
-	eDebug("%dk total video mem", available/1024);
+	eDebug("[fb] %s: %dk total video mem", fb, available/1024);
 	// The first 1920x1080x4 bytes are reserved
 	// After that we can take 1280x720x4 bytes for our virtual framebuffer
 	available -= 1920*1080*4;
-	eDebug("%dk usable video mem", available/1024);
+	eDebug("[fb] %s: %dk usable video mem", fb, available/1024);
 	lfb=(unsigned char*)mmap(0, available, PROT_WRITE|PROT_READ, MAP_SHARED, fbFd, 1920*1080*4);
 #else
-	eDebug("%dk video mem", available/1024);
+	eDebug("[fb] %s: %dk video mem", fb, available/1024);
 	lfb=(unsigned char*)mmap(0, available, PROT_WRITE|PROT_READ, MAP_SHARED, fbFd, 0);
 #endif
 	if (!lfb)
@@ -91,7 +91,7 @@ nolfb:
 		::close(fbFd);
 		fbFd = -1;
 	}
-	printf("framebuffer not available.\n");
+	eDebug("[fb] framebuffer %s not available", fb);
 	return;
 }
 

--- a/lib/gdi/fb.h
+++ b/lib/gdi/fb.h
@@ -7,6 +7,10 @@
 	#include <linux/stmfb.h>
 #endif
 
+#ifndef FB_DEV
+# define FB_DEV "/dev/fb0"
+#endif
+
 class fbClass
 {
 	int fbFd;
@@ -31,7 +35,7 @@ class fbClass
 	int m_number_of_pages;
 	int m_phys_mem;
 #ifdef SWIG
-	fbClass(const char *fb="/dev/fb0");
+	fbClass(const char *fb=FB_DEV);
 	~fbClass();
 public:
 #else
@@ -54,7 +58,7 @@ public:
 	unsigned int Stride() { return stride; }
 	fb_cmap *CMAP() { return &cmap; }
 
-	fbClass(const char *fb="/dev/fb0");
+	fbClass(const char *fb=FB_DEV);
 	~fbClass();
 
 			// low level gfx stuff

--- a/lib/gdi/fblcd.cpp
+++ b/lib/gdi/fblcd.cpp
@@ -57,7 +57,7 @@ eFbLCD::eFbLCD(const char *fb)
 
 	m_available = fix.smem_len;
 	m_phys_mem = fix.smem_start;
-	eDebug("%dk video mem", m_available / 1024);
+	eDebug("[eFbLCD] %s %dk video mem", fb, m_available / 1024);
 	_buffer=(unsigned char*)mmap(0, m_available, PROT_WRITE|PROT_READ, MAP_SHARED, lcdfd, 0);
 	if (!_buffer)
 	{
@@ -78,7 +78,7 @@ nolfb:
 		::close(lcdfd);
 		lcdfd = -1;
 	}
-	printf("framebuffer not available.\n");
+	eDebug("[eFbLCD] framebuffer %s not available", fb);
 	return;
 }
 

--- a/lib/gdi/fblcd.h
+++ b/lib/gdi/fblcd.h
@@ -10,6 +10,10 @@
 #define FBIO_WAITFORVSYNC _IOW('F', 0x20, uint32_t)
 #endif
 
+#ifndef LCD_DEV
+# define LCD_DEV "/dev/fb1"
+#endif
+
 class eFbLCD: public eLCD
 {
 	int m_xRes, m_yRes, m_bpp;
@@ -30,7 +34,7 @@ class eFbLCD: public eLCD
 			// low level gfx stuff
 	int putCMAP();
 public:
-	eFbLCD(const char *fb="/dev/fb1");
+	eFbLCD(const char *fb=LCD_DEV);
 	~eFbLCD();
 	bool detected() { return m_available; }
 	eSize size() { return eSize(m_xRes, m_yRes); }


### PR DESCRIPTION
Show framebuffername in eDebug messages
Setup framebuffer device names in #defines instead
of hardcoded. This allows for future setup at build
configure time.