### PR TITLE
NimManager: shuffle the tuner types around a bit more.

### DIFF
--- a/lib/python/Components/NimManager.py
+++ b/lib/python/Components/NimManager.py
@@ -174,7 +174,7 @@ class SecConfigure:
 		try:
 			for slot in nim_slots:
 				if slot.frontend_id is not None:
-					types = [type for type in ["DVB-C", "DVB-T2", "DVB-T", "DVB-S2", "DVB-S", "ATSC"] if eDVBResourceManager.getInstance().frontendIsCompatible(slot.frontend_id, type)]
+					types = [type for type in ["DVB-C", "DVB-T", "DVB-T2", "DVB-S2", "DVB-S", "ATSC"] if eDVBResourceManager.getInstance().frontendIsCompatible(slot.frontend_id, type)]
 					if "DVB-T2" in types:
 						# DVB-T2 implies DVB-T support
 						types.remove("DVB-T")


### PR DESCRIPTION
Additional to 4f9db8d0fedceba60da390d0801320b6d108cb70.

'Actually when looking at DVB-T2 it should be after DVB-T
 in that list otherwise types.remove won't work (the initial
 patch was only made to get DVB-C work, DVB-T also works
 with it though).'

Change suggested by sundtek.
