### PR TITLE
eRCDevice destructor must be virtual

### DIFF
--- a/lib/driver/rc.h
+++ b/lib/driver/rc.h
@@ -35,7 +35,7 @@ public:
 	 * \param input The \ref eRCDriver where this remote gets its codes from.
 	 */
 	eRCDevice(std::string id, eRCDriver *input);
-	~eRCDevice();
+	virtual ~eRCDevice();
 	/**
 	 * \brief Handles a device specific code.
 	 *


### PR DESCRIPTION
Code will call the destructor for derived classes through this one, so the d'tor must be virtual
to prevent memory leaks.

see:
http://forums.openpli.org/topic/34487-enigma2-warnings-promoted-to-error-via-werror/page-3#entry526794

Fixes the following compiler warning:
...lib/driver/rc.cpp:56:11: warning: deleting object of abstract class type 'eRCDevice' which has non-virtual destructor will cause undefined behaviour [-Wdelete-non-virtual-dtor]
   delete *i;
