### PR TITLE
EPG add timer: auto resolve conflict for alternative services

### DIFF
--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
@@ -27,7 +27,7 @@ from Tools.LoadPixmap import LoadPixmap
 from Tools.Alternatives import CompareWithAlternatives
 from Tools import Notifications
 from enigma import eEPGCache, eListbox, gFont, eListboxPythonMultiContent, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_HALIGN_CENTER,\
-	RT_VALIGN_CENTER, RT_WRAP, BT_SCALE, BT_KEEP_ASPECT_RATIO, eSize, eRect, eTimer, getBestPlayableServiceReference, loadPNG
+	RT_VALIGN_CENTER, RT_WRAP, BT_SCALE, BT_KEEP_ASPECT_RATIO, eSize, eRect, eTimer, getBestPlayableServiceReference, loadPNG, eServiceReference
 from GraphMultiEpgSetup import GraphMultiEpgSetup
 from time import localtime, time, strftime
 
@@ -1066,6 +1066,9 @@ class GraphMultiEPG(Screen, HelpableScreen):
 							entry.end -= 30
 							change_time = True
 						elif entry.begin == conflict_end:
+							entry.begin += 30
+							change_time = True
+						elif entry.begin == conflict_begin and (entry.service_ref and entry.service_ref.ref and entry.service_ref.ref.flags & eServiceReference.isGroup):
 							entry.begin += 30
 							change_time = True
 						if change_time:

--- a/lib/python/Screens/EpgSelection.py
+++ b/lib/python/Screens/EpgSelection.py
@@ -1109,6 +1109,9 @@ class EPGSelection(Screen, HelpableScreen):
 						elif entry.begin == conflict_end:
 							entry.begin += 30
 							change_time = True
+						elif entry.begin == conflict_begin and (entry.service_ref and entry.service_ref.ref and entry.service_ref.ref.flags & eServiceReference.isGroup):
+							entry.begin += 30
+							change_time = True
 						if change_time:
 							simulTimerList = self.session.nav.RecordTimer.record(entry)
 					if simulTimerList is not None:

--- a/lib/python/Screens/EventView.py
+++ b/lib/python/Screens/EventView.py
@@ -172,6 +172,9 @@ class EventViewBase:
 						elif entry.begin == conflict_end:
 							entry.begin += 30
 							change_time = True
+						elif entry.begin == conflict_begin and (entry.service_ref and entry.service_ref.ref and entry.service_ref.ref.flags & eServiceReference.isGroup):
+							entry.begin += 30
+							change_time = True
 						if change_time:
 							simulTimerList = self.session.nav.RecordTimer.record(entry)
 					if simulTimerList is not None:


### PR DESCRIPTION
-when alternative timer  begin same as conflict timer add 30 sec. for begin

example:
tuner A 13e
tuner B 19e
add timer 13e
add timer(alternative 13-19e) --> conflict

first start alternative timer--> tuner A
two start  timer--> tuner A not available
add 30 sec --> alternative timer use tuner B
