### PR TITLE
Show Video Wizard in first stage.

### DIFF
--- a/lib/python/Screens/StartWizard.py
+++ b/lib/python/Screens/StartWizard.py
@@ -36,6 +36,6 @@ class StartWizard(WizardLanguage, Rc):
 		config.misc.firstrun.save()
 		configfile.save()
 
-wizardManager.registerWizard(LanguageWizard, config.misc.languageselected.value, priority = 0)
-wizardManager.registerWizard(VideoWizard, config.misc.videowizardenabled.value, priority = 2)
+wizardManager.registerWizard(VideoWizard, config.misc.videowizardenabled.value, priority = 0)
+wizardManager.registerWizard(LanguageWizard, config.misc.languageselected.value, priority = 2)
 wizardManager.registerWizard(StartWizard, config.misc.firstrun.value, priority = 20)


### PR DESCRIPTION
The user @linarense https://www.lonasdigital.com/showthread.php?t=68158&page=20&p=409446 reported that it is very likely that older TVs need to first set  video, would otherwise be impossible to obtain any video signal.

So let's take note and apply ;)
