### PR TITLE
E2 serviceMP3 pause/unpause problem.

### DIFF
--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -937,13 +937,24 @@ RESULT eServiceMP3::trickSeek(gdouble ratio)
 {
 	if (!m_gst_playbin)
 		return -1;
+	GstState state, pending;
 	if (ratio > -0.01 && ratio < 0.01)
 	{
 		gst_element_set_state(m_gst_playbin, GST_STATE_PAUSED);
+		/* pipeline sometimes block due to audio track issue off gstreamer.
+		If the pipeline is blocked up on pending state change to paused ,
+        this issue is solved be just reslecting the current audio track.*/
+		gst_element_get_state(m_gst_playbin, &state, &pending, 1 * GST_SECOND);
+		if (state == GST_STATE_PLAYING && pending == GST_STATE_PAUSED)
+		{
+			if (m_currentAudioStream >= 0)
+				selectTrack(m_currentAudioStream);
+			else
+				selectTrack(0);
+		}
 		return 0;
 	}
 
-#if GST_VERSION_MAJOR >= 1
 	bool unpause = (m_currentTrickRatio == 1.0 && ratio == 1.0);
 	if (unpause)
 	{
@@ -976,7 +987,6 @@ RESULT eServiceMP3::trickSeek(gdouble ratio)
 		if (!strcmp(name, "filesrc") || !strcmp(name, "souphttpsrc"))
 		{
 			GstStateChangeReturn ret;
-			GstState state, pending;
 			/* make sure that last state change was successfull */
 			ret = gst_element_get_state(m_gst_playbin, &state, &pending, 0);
 			if (ret == GST_STATE_CHANGE_SUCCESS)
@@ -998,7 +1008,7 @@ RESULT eServiceMP3::trickSeek(gdouble ratio)
 seek_unpause:
 		eDebugNoNewLine(", doing seeking unpause\n");
 	}
-#endif
+
 	m_currentTrickRatio = ratio;
 
 	bool validposition = false;
@@ -1010,7 +1020,9 @@ seek_unpause:
 		pos = pts * 11111LL;
 	}
 
-	gst_element_set_state(m_gst_playbin, GST_STATE_PLAYING);
+	gst_element_get_state(m_gst_playbin, &state, &pending, 1 * GST_SECOND);
+	if (state != GST_STATE_PLAYING)
+		gst_element_set_state(m_gst_playbin, GST_STATE_PLAYING);
 
 	if (validposition)
 	{
@@ -1067,7 +1079,7 @@ RESULT eServiceMP3::getPlayPosition(pts_t &pts)
 
 	if ((audioSink || videoSink) && !m_paused)
 	{
-		g_signal_emit_by_name(audioSink ? audioSink : videoSink, "get-decoder-time", &pos);
+		g_signal_emit_by_name(videoSink ? videoSink : audioSink, "get-decoder-time", &pos);
 		if (!GST_CLOCK_TIME_IS_VALID(pos)) return -1;
 	}
 	else


### PR DESCRIPTION
 On some stb and with some media or (to) rapid fingers of user,
 We may end up with gst pipeline blocked in state playing pending paused.
 It also block's out the further regular process off the media.
 The result is that user can not unpause movie anymore. Only thing left
 is stopping the media. I found out that the pipeline lost track of used audio.
 That is the reason why pipeline remains blocked.
 To solve this : we need to reselect to current used track. This unblocks the pipeline,
 gstreamer will proceed with change to pause. Then we can go further and go back to play.
 This patch will If a pipeline problem arise when going to paused reselect the current
 audiotrack in use. The pipeline will be unblocked and we are back ok.
 No stb short freeze or obligation to stop the media.
 The second thing is the rapid finger problem. This issue is especially on the
 faster stb's such as vuduo2 solo2 or ...
 This patch will solve that without blocking the media.
 In this patch I also set the getplayposition to video first if video is in use.
 That is better video is always using internal codecs while audio many times uses
 software codecs. Video is then faster and more precise.
 In this patch I also adapted the good pause/unpause implementation of mx3L
 To be valid on older gst-0.10 (must be tested by someone who still build self with gst-0.10)
 According to gst-0.10 manual it should all be ok since all function used by mx3L for this
 pause unpause did not changed in between gst-0.10 and gst-1.0.
 Then I also when performing normal trickseek actually only ok fast forward up to max 4x.
 Only perform gst-set-state to playing if the pipeline is not playing.
 It does not make any sence to set a pipeline to playing which already is playing.

```
modified:   lib/service/servicemp3.cpp
```

Signed-off-by: littlesat littlesat99@yahoo.com
