### PR TITLE
Solve issue with showing InfoBar in DVD player when toggling it with OK

### DIFF
--- a/lib/python/Screens/DVD.py
+++ b/lib/python/Screens/DVD.py
@@ -512,8 +512,6 @@ class DVDPlayer(Screen, InfoBarBase, InfoBarNotifications, InfoBarSeek, InfoBarP
 			self.okButton()
 			print "[DVD] keyOk"
 			self.toggleInfo()
-			if not self.in_menu:
-				self.toggleShow()
 
 	def keyCancel(self):
 		self.askLeavePlayer()


### PR DESCRIPTION
See: http://forums.openpli.org/topic/41394-et9000-beim-dvd-player-keine-infobar-einblendbar/
