### PR TITLE
frontend: fix incorrect init and usage of LOF offset

### DIFF
--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -485,6 +485,7 @@ eDVBFrontend::eDVBFrontend(const char *devicenodename, int fe, int &ok, bool sim
 
 	m_delsys.clear();
 
+	m_data[FREQ_OFFSET] = 0;
 	m_idleInputpower[0]=m_idleInputpower[1]=0;
 
 	char fileName[32] = {0};
@@ -1288,7 +1289,7 @@ int eDVBFrontend::readFrontendData(int type)
 			{
 				return 0;
 			}
-			return p.u.data + m_data[FREQ_OFFSET];
+			return type == feSatellite ? p.u.data + m_data[FREQ_OFFSET] : p.u.data;
 		}
 	}
 	return 0;


### PR DESCRIPTION
The local oscillator frequency offset is incorrectly initialized to -1.

Also when enigma was requesting the frequency, offset value was added for systems other than satellite.
This was causing changes to frequency by -1 Hz. Not a big deal, but when using a multituner device
that supports dvb-s/c/t then changing from s to c/t offset (eg 9750000-1) was added in frequency causing tune failure.

This patch initializes FREQ_OFFSET to correct value 0 and takes into consideration system to be satellite in order to add up offset.
