### PR TITLE
Update EPG Days for default (temp)

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -435,7 +435,7 @@ def InitUsageConfig():
 	config.epg.netmed.addNotifier(EpgSettingsChanged)
 	config.epg.virgin.addNotifier(EpgSettingsChanged)
 
-	config.epg.maxdays = ConfigSelectionNumber(min = 1, max = 365, stepwidth = 1, default = 7, wraparound = True)
+	config.epg.maxdays = ConfigSelectionNumber(min = 1, max = 365, stepwidth = 1, default = 3, wraparound = True)
 	def EpgmaxdaysChanged(configElement):
 		from enigma import eEPGCache
 		eEPGCache.getInstance().setEpgmaxdays(config.epg.maxdays.getValue())

--- a/lib/python/Plugins/Extensions/LDteam/LdSet.py
+++ b/lib/python/Plugins/Extensions/LDteam/LdSet.py
@@ -107,7 +107,7 @@ config.epg.viasat.addNotifier(EpgSettingsChanged)
 config.epg.netmed.addNotifier(EpgSettingsChanged)
 config.epg.virgin.addNotifier(EpgSettingsChanged)
 
-config.epg.maxdays = ConfigSelectionNumber(min = 1, max = 365, stepwidth = 1, default = 7, wraparound = True)
+config.epg.maxdays = ConfigSelectionNumber(min = 1, max = 365, stepwidth = 1, default = 3, wraparound = True)
 def EpgmaxdaysChanged(configElement):
 	from enigma import eEPGCache
 	eEPGCache.getInstance().setEpgmaxdays(config.epg.maxdays.getValue())


### PR DESCRIPTION
- To avoid getting blank EPG we return to 3 days by default.
- New tables pid are updated shortly and it will return to 7 days by default.
- A little patience please. I do not know the pattern for recognizing the new tables pid.
- I need to more testing with the dvbsnoop :(
