### PR TITLE
Add variable noaudio in setTarget

### DIFF
--- a/lib/python/Screens/PictureInPicture.py
+++ b/lib/python/Screens/PictureInPicture.py
@@ -183,12 +183,8 @@ class PictureInPicture(Screen):
 				if not config.usage.hide_zap_errors.value:
 					Notifications.AddPopup(text = _("No free tuner!"), type = MessageBox.TYPE_ERROR, timeout = 5, id = "ZapPipError")
 				return False
-			if config.av.pip_mode.value == "external":
-				useaudio = 1
-			else:
-				useaudio = -1
 			self.pipservice = eServiceCenter.getInstance().play(ref)
-			if self.pipservice and not self.pipservice.setTarget(useaudio):
+			if self.pipservice and not self.pipservice.setTarget(1, True):
 				if hasattr(self, "dishpipActive") and self.dishpipActive is not None:
 					self.dishpipActive.startPiPService(ref)
 				self.pipservice.start()

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -948,7 +948,7 @@ public:
 	virtual RESULT start()=0;
 	virtual RESULT stop()=0;
 			/* might have to be changed... */
-	virtual RESULT setTarget(int target)=0;
+	virtual RESULT setTarget(int target, bool noaudio = false)=0;
 	virtual SWIG_VOID(RESULT) seek(ePtr<iSeekableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) pause(ePtr<iPauseableService> &SWIG_OUTPUT)=0;
 	virtual SWIG_VOID(RESULT) info(ePtr<iServiceInformation> &SWIG_OUTPUT)=0;

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1439,16 +1439,10 @@ RESULT eDVBServicePlay::stop()
 	return 0;
 }
 
-RESULT eDVBServicePlay::setTarget(int target)
+RESULT eDVBServicePlay::setTarget(int target, bool noaudio = false)
 {
-	/* target -1 used for pip, change decoder index to 1 */
-	if (target == -1)
-	{
-		target = 1;
-		m_noaudio = true;
-	}
-
 	m_decoder_index = target;
+	m_noaudio = noaudio;
 	return 0;
 }
 

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -100,7 +100,7 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT seek(ePtr<iSeekableService> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -466,12 +466,6 @@ RESULT eServiceDVD::stop()
 	return 0;
 }
 
-RESULT eServiceDVD::setTarget(int /*target*/)
-{
-	eDebug("[eServiceDVD] setTarget");
-	return -1;
-}
-
 RESULT eServiceDVD::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr = this;

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -65,6 +65,7 @@ class eServiceDVD: public iPlayableService, public iPauseableService, public iSe
 public:
 	virtual ~eServiceDVD();
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr);
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
@@ -80,7 +81,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 	RESULT info(ePtr<iServiceInformation> &ptr);
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -138,16 +138,10 @@ RESULT eServiceHDMI::stop()
 	return 0;
 }
 
-RESULT eServiceHDMI::setTarget(int target)
+RESULT eServiceHDMI::setTarget(int target, bool noaudio = false)
 {
-	/* target -1 used for pip, change decoder index to 1 */
-	if (target == -1)
-	{
-		target = 1;
-		m_noaudio = true;
-	}
-
 	m_decoder_index = target;
+	m_noaudio = noaudio;
 	return 0;
 }
 

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -46,7 +46,7 @@ public:
 	RESULT connectEvent(const Slot2<void, iPlayableService*, int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
+	RESULT setTarget(int target, bool noaudio);
 
 	RESULT pause(ePtr<iPauseableService> &ptr) { ptr = 0; return -1; }
 	RESULT seek(ePtr<iSeekableService> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicemp3.cpp
+++ b/lib/service/servicemp3.cpp
@@ -835,11 +835,6 @@ RESULT eServiceMP3::stop()
 	return 0;
 }
 
-RESULT eServiceMP3::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceMP3::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -132,7 +132,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -146,6 +145,7 @@ public:
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
 	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
 	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -56,7 +56,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -87,7 +87,7 @@ public:
 	RESULT info(ePtr<iServiceInformation>&);
 
 	// not implemented
-	RESULT setTarget(int target) { return -1; };
+	RESULT setTarget(int target, bool noaudio = false) { return -1; };
 	RESULT setSlowMotion(int ratio) { return -1; };
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };

--- a/lib/service/servicexine.cpp
+++ b/lib/service/servicexine.cpp
@@ -212,11 +212,6 @@ RESULT eServiceXine::stop()
 	return 0;
 }
 
-RESULT eServiceXine::setTarget(int target)
-{
-	return -1;
-}
-
 RESULT eServiceXine::pause(ePtr<iPauseableService> &ptr)
 {
 	ptr=this;

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -52,7 +52,6 @@ public:
 	RESULT connectEvent(const Slot2<void,iPlayableService*,int> &event, ePtr<eConnection> &connection);
 	RESULT start();
 	RESULT stop();
-	RESULT setTarget(int target);
 
 	RESULT pause(ePtr<iPauseableService> &ptr);
 	RESULT setSlowMotion(int ratio);
@@ -61,6 +60,7 @@ public:
 	RESULT seek(ePtr<iSeekableService> &ptr);
 
 		// not implemented (yet)
+	RESULT setTarget(int target, bool noaudio = false) { return -1; }
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = 0; return -1; }
 	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }


### PR DESCRIPTION
This allow specify not use audio in decoder.
Currently used for pip.

By default, set noaudio to false to keep compatibility.
In classes, where setTarget not implemented, moves it to the header files.