### PR TITLE
[StreamingClientsInfo] Allow stopping all streams from

### DIFF
--- a/lib/dvb/streamserver.cpp
+++ b/lib/dvb/streamserver.cpp
@@ -313,6 +313,19 @@ void eStreamServer::stopStream()
 	}
 }
 
+bool eStreamServer::stopStreamClient(const std::string remotehost, const std::string serviceref)
+{
+	for (eSmartPtrList<eStreamClient>::iterator it = clients.begin(); it != clients.end(); ++it)
+	{
+		if(it->getRemoteHost() == remotehost && it->getServiceref() == serviceref)
+		{
+			it->stopStream();
+			return true;
+		}
+	}
+	return false;
+}
+
 PyObject *eStreamServer::getConnectedClients()
 {
 	ePyObject ret;

--- a/lib/dvb/streamserver.h
+++ b/lib/dvb/streamserver.h
@@ -66,6 +66,7 @@ public:
 
 	static eStreamServer *getInstance();
 	void stopStream();
+	bool stopStreamClient(const std::string remotehost, const std::string serviceref);
 	PyObject *getConnectedClients();
 };
 

--- a/lib/python/Screens/StreamingClientsInfo.py
+++ b/lib/python/Screens/StreamingClientsInfo.py
@@ -30,16 +30,18 @@ class StreamingClientsInfo(Screen):
 		self["ScrollLabel"] = ScrollLabel()
 
 		self["key_red"] = Button(_("Close"))
+		self["key_blue"] = Button()
 		self["actions"] = ActionMap(["ColorActions", "SetupActions", "DirectionActions"],
 			{
 				"cancel": self.exit,
 				"ok": self.exit,
 				"red": self.exit,
+				"blue": self.stopStreams,
 				"up": self["ScrollLabel"].pageUp,
 				"down": self["ScrollLabel"].pageDown
 			})
 
-		self.onLayoutFinish.append(self.update_info)
+		self.onLayoutFinish.append(self.start)
 
 	def exit(self):
 		self.stop()
@@ -48,6 +50,7 @@ class StreamingClientsInfo(Screen):
 	def start(self):
 		if self.update_info not in self.DynamicTimer.callback:
 			self.DynamicTimer.callback.append(self.update_info)
+		self.DynamicTimer.start(0)
 
 	def stop(self):
 		if self.update_info in self.DynamicTimer.callback:
@@ -64,4 +67,12 @@ class StreamingClientsInfo(Screen):
 		text = clients.getText()
 		self["liste"].setText(text or _("No stream clients"))
 		self["ScrollLabel"].setText(text or _("No stream clients"))
+		self["key_blue"].setText(text and _("Stop Streams") or "")
 		self.DynamicTimer.start(5000)
+
+	def stopStreams(self):
+		streamServer = eStreamServer.getInstance()
+		if not streamServer:
+			return
+		for x in streamServer.getConnectedClients():
+			streamServer.stopStream()


### PR DESCRIPTION
 StreamingClientsInfo

Allows to stop all streams, releasing tuners back to enigma2

* streamserver: introduce stopStreamClient function

The stopStreamClient can be used to stop specific stream
by passing ip and serviceref.

TODO: Above function should be integrated into StreamClientInfo,
where  streaming clients can be selected and stopped.

A possible improvement with a small modification might be the pass
of ip or serviceref only, in order to stop all clients from the same ip
or all clients on the same serviceref.