### PR TITLE
scan: read network id using getTableIdExtension

### DIFF
--- a/lib/dvb/scan.cpp
+++ b/lib/dvb/scan.cpp
@@ -752,9 +752,9 @@ void eDVBScan::channelDone()
 		std::vector<NetworkInformationSection*>::const_iterator i;
 		for (i = m_NIT->getSections().begin(); i != m_NIT->getSections().end(); ++i)
 		{
-			if (m_networkid && m_networkid != (*i)->getNetworkId())
+			if (m_networkid && m_networkid != (*i)->getTableIdExtension()) // in NIT this is the network id
 			{
-				SCAN_eDebug("[eDVBScan] ignoring NetworkId %d!", (*i)->getNetworkId());
+				SCAN_eDebug("[eDVBScan] ignoring NetworkId %d!", (*i)->getTableIdExtension());
 				continue;
 			}
 


### PR DESCRIPTION
It seems that getNetworkId is not really required on libdvbsi++ since
the LongSection already provides network id using getTableIdExtension