### PR TITLE
eStaticServiceDVBPVRInformation: use sIsCrypted to return

### DIFF
--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -436,6 +436,8 @@ int eStaticServiceDVBPVRInformation::getInfo(const eServiceReference &ref, int w
 			return m_parser.m_time_create;
 		else
 			return iServiceInformation::resNA;
+	case iServiceInformation::sIsCrypted:
+		return m_parser.m_scrambled;
 	default:
 		return iServiceInformation::resNA;
 	}


### PR DESCRIPTION
 m_scrambled

We can query from python plugins if recording is crypted.

info.getInfo(sref, iServiceInformation.sIsCrypted)