### PR TITLE
Fix .eit file not being created when timeshift recording

### DIFF
--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -408,9 +408,6 @@ private:
 	RESULT lookupEventTime(const eServiceReference &service, time_t, const eventData *&, int direction=0);
 
 public:
-	// eit_event_struct's are plain dvb eit_events .. it's not safe to use them after cache unlock
-	RESULT saveEventToFile(const char* filename, const eServiceReference &service, int eit_event_id, time_t begTime, time_t endTime);
-
 	// Events are parsed epg events.. it's safe to use them after cache unlock
 	// after use the Event pointer must be released using "delete".
 	RESULT lookupEventId(const eServiceReference &service, int event_id, Event* &);
@@ -429,6 +426,9 @@ public:
 	};
 	PyObject *lookupEvent(SWIG_PYOBJECT(ePyObject) list, SWIG_PYOBJECT(ePyObject) convertFunc=(PyObject*)0);
 	PyObject *search(SWIG_PYOBJECT(ePyObject));
+
+	/* Used by servicedvbrecord.cpp, timeshift, etc. to write the EIT file */
+	RESULT saveEventToFile(const char* filename, const eServiceReference &service, int eit_event_id, time_t begTime, time_t endTime);
 
 	// eServiceEvent are parsed epg events.. it's safe to use them after cache unlock
 	// for use from python ( members: m_start_time, m_duration, m_short_description, m_extended_description )

--- a/lib/python/Components/Timeshift.py
+++ b/lib/python/Components/Timeshift.py
@@ -1237,7 +1237,7 @@ class InfoBarTimeshift:
 	def ptsCreateEITFile(self, filename):
 		if self.pts_curevent_eventid is not None:
 			try:
-				serviceref = ServiceReference(self.session.nav.getCurrentlyPlayingServiceOrGroup()).ref.toString()
+				serviceref = ServiceReference(self.session.nav.getCurrentlyPlayingServiceOrGroup()).ref
 				eEPGCache.getInstance().saveEventToFile(filename+".eit", serviceref, self.pts_curevent_eventid, -1, -1)
 			except Exception, errormsg:
 				print "[TIMESHIFT] - %s" % errormsg


### PR DESCRIPTION
 created

When a new timeshift file is started, code is called to create a .eit file
for the timeshift recording from the EPG.

However, when InfoBarTimeshift.ptsCreateEITFile() calls
eEPGCache::saveEventToFile(), the call fails with a caught exception,
whic is logged to the debug file:
[Timeshift] 'eEPGCache' object has no attribute 'saveEventToFile'

The cause is that eEPGCache::saveEventToFile() is hidden from SWIG
by an #ifndef SWIG.

In addition, InfoBarTimeshift.ptsCreateEITFile() calls
eEPGCache::saveEventToFile() with a string representation
of the serviceref in its service argument when the code expects
the service argument to be an eServiceReference.

This means that EIT information isn't saved for the timeshift buffer
when the timeshift buffer is saved, so that information is not
available in screens that would display it, like INFO when playing
a recording.

The fix moves the declaration of eEPGCache::saveEventToFile()
to where it is visible to SWIG and calls eEPGCache::saveEventToFile()
with the service argument in the correct form.

Bug replication:

In live TV, view a program timeshifted, and then use CH+/- to change
channels.  When the 'You seem to be in timeshift' popup appears,
select 'Yes, but save timeshift as a movie and stop recording.

After the 'Timeshift saved to your harddisk!' has appeared, enter
the MovieSelection screen and play the saved timeshift. Pressing
INFO or OK, OK will not display the recording's EIT short or long
description, because it is not available.

Also, examining the timeshift directory in the commandline information
will show that no .eit files are being created for timeshift
recordings.