### PR TITLE
Update for test

### DIFF
--- a/lib/service/servicemp3.h
+++ b/lib/service/servicemp3.h
@@ -243,6 +243,7 @@ public:
 		gboolean is_video;
 		gboolean is_streaming;
 		gboolean is_hls;
+		std::string protocol;
 		sourceStream()
 			:audiotype(atUnknown), containertype(ctNone), is_audio(FALSE), is_video(FALSE), is_streaming(FALSE), is_hls(FALSE)
 		{


### PR DESCRIPTION
Add patchs for test in OpenLD:

- [PATCH 1/2] servicemp3: add protocol info about stream.
- [PATCH 2/2] servicemp3: use unpause by kf-seeking only when necessary

 From: mx3L <mx3ldev@gmail.com>
----------------------------------------------------------
1. We are un-pausing streams by seeking to current position.
That is only neccessary when stream could timeout.

If it cannot like in local media or when souphttpsrc
element(gstreamer1.0) is used, then there is no reason
to un-pause by seeking, we just need change the state
of pipeline to PLAYING state

2. We are doing unnecessary non-keyframe seeking when
un-pausing streams.

According to gstreamer docs non-keyframe seeking pushes
buffers from keyframe and just informs us by SEGMENT event
from which buffer should decoder start decoding.

We are ignoring this information in our dvbmediasink
and are processing buffers from keyframe.
non-keyframe seeking causes unnecessary overhead by
looking for start position, which could result in
unsuccessfull unpausing operation

related gstreamer doc:

http://cgit.freedesktop.org/gstreamer/gstreamer/tree/docs/design/part-seeking.txt
----------------------------------------------------------
Thanks mx3L: https://forums.openpli.org/topic/33133-et9200-problems-with-mp4-playback/?view=findpost&p=481793