### PR TITLE
Console: self.container=None as del container has some side effects

### DIFF
--- a/lib/python/Components/Console.py
+++ b/lib/python/Components/Console.py
@@ -30,7 +30,7 @@ class ConsoleItem:
 		del self.containers[self.name]
 		del self.container.dataAvail[:]
 		del self.container.appClosed[:]
-		del self.container
+		self.container = None
 		callback = self.callback
 		if callback is not None:
 			data = ''.join(self.appResults)


### PR DESCRIPTION
I discovered it while creating the FlashImage application. By simply set
it to None instead of delete the container I do not have the side
effects. It happens that a previous executed command was executes some
times instead of the command you try to execute via ePopen recently.