### PR TITLE
smartptr: fix 64bit builds

### DIFF
--- a/lib/base/smartptr.h
+++ b/lib/base/smartptr.h
@@ -49,16 +49,13 @@ public:
 		if (ptr)
 			ptr->Release();
 	}
-	/* Horribly misnamed now, but why waste >9 bytes on each object just
-	 * to satisfy one ServiceEventTracker which doesn't even care about
-	 * the actual type it returns. */
-	unsigned int getPtrString() const
+	/*
+	 * Horribly misnamed now, but ServiceEventTracker does not
+	 * care about the returned type.
+	 */
+	void *getPtrString() const
 	{
-#if defined(__aarch64__)
-		return (unsigned long)ptr;
-#else
-		return (unsigned int)ptr;
-#endif
+		return ptr;
 	}
 #ifndef SWIG
 	T* grabRef() { if (!ptr) return 0; ptr->AddRef(); return ptr; }


### PR DESCRIPTION
return a void pointer in getPtrString, instead of casting it to an
unsigned int (which is 32bit).
The result is used in a python comparison, which should handle a void
pointer just as well.