### PR TITLE
http(s)stream - reduce 1 second to 500ms this is a compromise

### DIFF
--- a/lib/base/httpsstream.cpp
+++ b/lib/base/httpsstream.cpp
@@ -3,7 +3,6 @@
 #include <lib/base/httpsstream.h>
 #include <lib/base/eerror.h>
 #include <lib/base/wrappers.h>
-#include <lib/base/nconfig.h> // access to python config
 
 // for shutdown
 #include <sys/socket.h>
@@ -311,8 +310,7 @@ int eHttpsStream::open(const char *url)
 void eHttpsStream::thread()
 {
 	hasStarted();
-	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
-		usleep(500000); // wait half a second
+	usleep(500000); // wait half a second in general as not only fallback receiver needs this.
 	std::string currenturl, newurl;
 	currenturl = streamUrl;
 	for (unsigned int i = 0; i < 5; i++)

--- a/lib/base/httpstream.cpp
+++ b/lib/base/httpstream.cpp
@@ -3,7 +3,6 @@
 #include <lib/base/httpstream.h>
 #include <lib/base/eerror.h>
 #include <lib/base/wrappers.h>
-#include <lib/base/nconfig.h> // access to python config
 
 DEFINE_REF(eHttpStream);
 
@@ -236,8 +235,7 @@ int eHttpStream::open(const char *url)
 void eHttpStream::thread()
 {
 	hasStarted();
-	if (eConfigManager::getConfigBoolValue("config.usage.remote_fallback_enabled", false))
-		usleep(500000); // wait half a second
+	usleep(500000); // wait half a second in general as not only fallback receiver needs this.
 	std::string currenturl, newurl;
 	currenturl = streamUrl;
 	for (unsigned int i = 0; i < 5; i++)


### PR DESCRIPTION
 between ancient 1 second and the 500ms which was previously only active if
 remote fallback receiver was enabled remotechannelstreamconverter streams for
 example also had issue with no sleep that sometimes a zap was not successful.