### PR TITLE
eAUGTable: add an empty virtual dtor

### DIFF
--- a/lib/dvb/esection.h
+++ b/lib/dvb/esection.h
@@ -92,6 +92,7 @@ class eAUGTable: public sigc::trackable
 protected:
 	void slotTableReady(int);
 public:
+	virtual ~eAUGTable(){};
 	sigc::signal1<void, int> tableReady;
 	virtual void getNext(int err)=0;
 };


### PR DESCRIPTION
It seems to silence the following warnings:
dvb/eit.cpp:131:10: warning: deleting object of polymorphic class type 'AUTable<eTable<ATSCEventInformationSection> >'
which has non-virtual destructor might cause undefined behaviour [-Wdelete-non-virtual-dtor]