### PR TITLE
service: change 0 (null pointer) with nullptr

### DIFF
--- a/lib/service/service.cpp
+++ b/lib/service/service.cpp
@@ -149,7 +149,7 @@ RESULT eServiceCenter::play(const eServiceReference &ref, ePtr<iPlayableService>
 	std::map<int,ePtr<iServiceHandler> >::iterator i = handler.find(ref.type);
 	if (i == handler.end())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 	return i->second->play(ref, ptr);
@@ -160,7 +160,7 @@ RESULT eServiceCenter::record(const eServiceReference &ref, ePtr<iRecordableServ
 	std::map<int,ePtr<iServiceHandler> >::iterator i = handler.find(ref.type);
 	if (i == handler.end())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 	return i->second->record(ref, ptr);
@@ -171,7 +171,7 @@ RESULT eServiceCenter::list(const eServiceReference &ref, ePtr<iListableService>
 	std::map<int,ePtr<iServiceHandler> >::iterator i = handler.find(ref.type);
 	if (i == handler.end())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 	return i->second->list(ref, ptr);
@@ -182,7 +182,7 @@ RESULT eServiceCenter::info(const eServiceReference &ref, ePtr<iStaticServiceInf
 	std::map<int,ePtr<iServiceHandler> >::iterator i = handler.find(ref.type);
 	if (i == handler.end())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 	return i->second->info(ref, ptr);
@@ -193,7 +193,7 @@ RESULT eServiceCenter::offlineOperations(const eServiceReference &ref, ePtr<iSer
 	std::map<int,ePtr<iServiceHandler> >::iterator i = handler.find(ref.type);
 	if (i == handler.end())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 	return i->second->offlineOperations(ref, ptr);
@@ -257,7 +257,7 @@ int eServiceCenter::getServiceTypeForExtension(const std::string &str)
 	/* default handlers */
 RESULT iServiceHandler::info(const eServiceReference &, ePtr<iStaticServiceInformation> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -942,7 +942,7 @@ RESULT eServiceFactoryDVB::list(const eServiceReference &ref, ePtr<iListableServ
 	ePtr<eDVBServiceList> list = new eDVBServiceList(ref);
 	if (list->startQuery())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 
@@ -978,7 +978,7 @@ RESULT eServiceFactoryDVB::offlineOperations(const eServiceReference &ref, ePtr<
 {
 	if (ref.path.empty())
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	} else
 	{
@@ -1131,7 +1131,7 @@ void eDVBServicePlay::updateEpgCacheNowNext()
 {
 	bool update = false;
 	ePtr<eServiceEvent> next = 0;
-	ePtr<eServiceEvent> ptr = 0;
+	ePtr<eServiceEvent> ptr = nullptr;
 	eServiceReferenceDVB &ref = (eServiceReferenceDVB&) m_reference;
 	if (eEPGCache::getInstance() && eEPGCache::getInstance()->lookupEventTime(ref, -1, ptr) >= 0)
 	{
@@ -1470,7 +1470,7 @@ RESULT eDVBServicePlay::pause(ePtr<iPauseableService> &ptr)
 		   is not active, you should activate it when unpausing */
 	if ((!m_is_pvr) && (!m_timeshift_enabled))
 	{
-		ptr = 0;
+		ptr = nullptr;
 		return -1;
 	}
 
@@ -1579,7 +1579,7 @@ RESULT eDVBServicePlay::seek(ePtr<iSeekableService> &ptr)
 		return 0;
 	}
 
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
@@ -1738,7 +1738,7 @@ RESULT eDVBServicePlay::subServices(ePtr<iSubserviceList> &ptr)
 
 RESULT eDVBServicePlay::timeshift(ePtr<iTimeshiftService> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	if (m_timeshift_enabled || !m_is_pvr)
 	{
 		if (!m_timeshift_enabled)
@@ -1778,7 +1778,7 @@ RESULT eDVBServicePlay::cueSheet(ePtr<iCueSheet> &ptr)
 		ptr = this;
 		return 0;
 	}
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
@@ -1807,7 +1807,7 @@ RESULT eDVBServicePlay::streamed(ePtr<iStreamedService> &ptr)
 		ptr = this;
 		return 0;
 	}
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicedvb.h
+++ b/lib/service/servicedvb.h
@@ -114,7 +114,7 @@ public:
 	RESULT subtitle(ePtr<iSubtitleOutput> &ptr);
 	RESULT audioDelay(ePtr<iAudioDelay> &ptr);
 	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr);
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; }
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; }
 
 		// iStreamedService
 	RESULT streamed(ePtr<iStreamedService> &ptr);

--- a/lib/service/servicedvd.cpp
+++ b/lib/service/servicedvd.cpp
@@ -60,13 +60,13 @@ RESULT eServiceFactoryDVD::play(const eServiceReference &ref, ePtr<iPlayableServ
 
 RESULT eServiceFactoryDVD::record(const eServiceReference &/*ref*/, ePtr<iRecordableService> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
 RESULT eServiceFactoryDVD::list(const eServiceReference &, ePtr<iListableService> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
@@ -79,7 +79,7 @@ RESULT eServiceFactoryDVD::info(const eServiceReference &/*ref*/, ePtr<iStaticSe
 
 RESULT eServiceFactoryDVD::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
@@ -980,7 +980,7 @@ RESULT eServiceDVD::cueSheet(ePtr<iCueSheet> &ptr)
 		ptr = this;
 		return 0;
 	}
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicedvd.h
+++ b/lib/service/servicedvd.h
@@ -66,15 +66,15 @@ public:
 	virtual ~eServiceDVD();
 		// not implemented (yet)
 	RESULT setTarget(int target, bool noaudio = false) { return -1; }
-	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
+	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = nullptr; return -1; }
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr);
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; }
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; }
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; }
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; }
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; }
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; }
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; }
 	RESULT cueSheet(ePtr<iCueSheet> &ptr);
 	void setQpipMode(bool value, bool audio) { }
 

--- a/lib/service/servicefs.cpp
+++ b/lib/service/servicefs.cpp
@@ -82,7 +82,7 @@ RESULT eServiceFactoryFS::info(const eServiceReference &ref, ePtr<iStaticService
 
 RESULT eServiceFactoryFS::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicehdmi.cpp
+++ b/lib/service/servicehdmi.cpp
@@ -52,7 +52,7 @@ RESULT eServiceFactoryHDMI::record(const eServiceReference &ref, ePtr<iRecordabl
 
 RESULT eServiceFactoryHDMI::list(const eServiceReference &, ePtr<iListableService> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
@@ -64,7 +64,7 @@ RESULT eServiceFactoryHDMI::info(const eServiceReference &ref, ePtr<iStaticServi
 
 RESULT eServiceFactoryHDMI::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -48,22 +48,22 @@ public:
 	RESULT stop();
 	RESULT setTarget(int target, bool noaudio);
 
-	RESULT pause(ePtr<iPauseableService> &ptr) { ptr = 0; return -1; }
-	RESULT seek(ePtr<iSeekableService> &ptr) { ptr = 0; return -1; }
-	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = 0; return -1; }
-	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; }
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; }
+	RESULT pause(ePtr<iPauseableService> &ptr) { ptr = nullptr; return -1; }
+	RESULT seek(ePtr<iSeekableService> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = nullptr; return -1; }
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; }
 
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
-	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; }
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; }
 
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; }
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; }
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; }
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; }
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; }
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; }
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; }
 
 	RESULT info(ePtr<iServiceInformation>&);
 

--- a/lib/service/servicem2ts.cpp
+++ b/lib/service/servicem2ts.cpp
@@ -391,7 +391,7 @@ RESULT eServiceFactoryM2TS::info(const eServiceReference &ref, ePtr<iStaticServi
 
 RESULT eServiceFactoryM2TS::offlineOperations(const eServiceReference &ref, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicets.cpp
+++ b/lib/service/servicets.cpp
@@ -63,13 +63,13 @@ RESULT eServiceFactoryTS::list(const eServiceReference &, ePtr<iListableService>
 
 RESULT eServiceFactoryTS::info(const eServiceReference &ref, ePtr<iStaticServiceInformation> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 
 RESULT eServiceFactoryTS::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicets.h
+++ b/lib/service/servicets.h
@@ -61,17 +61,17 @@ public:
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = this; return 0; };
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; };
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; };
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; };
-	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; };
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; };
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; };
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; };
+	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; };
 	void setQpipMode(bool value, bool audio) { }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; };
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; };
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; };
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; };
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; };
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; };
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; };
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; };
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; };
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();

--- a/lib/service/servicewebts.cpp
+++ b/lib/service/servicewebts.cpp
@@ -77,7 +77,7 @@ RESULT eServiceFactoryWebTS::info(const eServiceReference &ref, ePtr<iStaticServ
 
 RESULT eServiceFactoryWebTS::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicewebts.h
+++ b/lib/service/servicewebts.h
@@ -91,17 +91,17 @@ public:
 	RESULT setFastForward(int ratio) { return -1; };
 	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = this; return 0; };
 	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = this; return 0; };
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; };
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; };
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; };
-	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; };
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; };
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; };
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; };
+	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; };
 	void setQpipMode(bool value, bool audio) { }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; };
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; };
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; };
-	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = 0; return -1; };
-	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = 0; return -1; };
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; };
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; };
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; };
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; };
+	RESULT stream(ePtr<iStreamableService> &ptr) { ptr = nullptr; return -1; };
+	RESULT streamed(ePtr<iStreamedService> &ptr) { ptr = nullptr; return -1; };
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; };
 
 	// iPausableService
 	RESULT pause();

--- a/lib/service/servicexine.cpp
+++ b/lib/service/servicexine.cpp
@@ -66,7 +66,7 @@ RESULT eServiceFactoryXine::info(const eServiceReference &ref, ePtr<iStaticServi
 
 RESULT eServiceFactoryXine::offlineOperations(const eServiceReference &, ePtr<iServiceOfflineOperations> &ptr)
 {
-	ptr = 0;
+	ptr = nullptr;
 	return -1;
 }
 

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -61,16 +61,16 @@ public:
 
 		// not implemented (yet)
 	RESULT setTarget(int target, bool noaudio = false) { return -1; }
-	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = 0; return -1; }
-	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = 0; return -1; }
-	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = 0; return -1; }
-	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = 0; return -1; }
-	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = 0; return -1; }
-	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = 0; return -1; }
-	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = 0; return -1; }
-	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = 0; return -1; }
-	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = 0; return -1; }
-	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = 0; return -1; }
+	RESULT audioChannel(ePtr<iAudioChannelSelection> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioTracks(ePtr<iAudioTrackSelection> &ptr) { ptr = nullptr; return -1; }
+	RESULT frontendInfo(ePtr<iFrontendInformation> &ptr) { ptr = nullptr; return -1; }
+	RESULT subServices(ePtr<iSubserviceList> &ptr) { ptr = nullptr; return -1; }
+	RESULT timeshift(ePtr<iTimeshiftService> &ptr) { ptr = nullptr; return -1; }
+	RESULT cueSheet(ePtr<iCueSheet> &ptr) { ptr = nullptr; return -1; }
+	RESULT subtitle(ePtr<iSubtitleOutput> &ptr) { ptr = nullptr; return -1; }
+	RESULT audioDelay(ePtr<iAudioDelay> &ptr) { ptr = nullptr; return -1; }
+	RESULT rdsDecoder(ePtr<iRdsDecoder> &ptr) { ptr = nullptr; return -1; }
+	RESULT keys(ePtr<iServiceKeys> &ptr) { ptr = nullptr; return -1; }
 
 		// iPausableService
 	RESULT pause();


### PR DESCRIPTION
Use nullptr pointer literal, since C++11 required by enigma2 now.

There are other places where 0 is used (or NULL) and those will be changed gradually.