### PR TITLE
[ActionMap.py] Add multiple contexts to HelpableActionMaps

### DIFF
--- a/lib/python/Components/ActionMap.py
+++ b/lib/python/Components/ActionMap.py
@@ -1,3 +1,5 @@
+from Tools.KeyBindings import queryKeyBinding
+
 from enigma import eActionMap
 
 
@@ -82,7 +84,8 @@ class NumberActionMap(ActionMap):
 class HelpableActionMap(ActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	Note that you can only use ONE context here!"""
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -93,25 +96,33 @@ class HelpableActionMap(ActionMap):
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
 	#
-	def __init__(self, parent, context, actions={}, prio=0, description=None):
+
+	def __init__(self, parent, contexts, actions={}, prio=0, description=None):
+		if not hasattr(contexts, '__iter__'):
+			contexts = [contexts]
 		self.description = description
-		alist = []
 		adict = {}
-		for (action, funchelp) in actions.iteritems():
-			# Check if this is a tuple.
-			if isinstance(funchelp, tuple):
-				alist.append((action, funchelp[1]))
-				adict[action] = funchelp[0]
-			else:
-				adict[action] = funchelp
-		ActionMap.__init__(self, [context], adict, prio)
-		parent.helpList.append((self, context, alist))
+		for context in contexts:
+			alist = []
+			for (action, funchelp) in actions.iteritems():
+				# Check if this is a tuple.
+				if isinstance(funchelp, tuple):
+					if queryKeyBinding(context, action):
+						alist.append((action, funchelp[1]))
+					adict[action] = funchelp[0]
+				else:
+					if queryKeyBinding(context, action):
+						alist.append((action, None))
+					adict[action] = funchelp
+			parent.helpList.append((self, context, alist))
+		ActionMap.__init__(self, contexts, adict, prio)
 
 
 class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
 	"""An Actionmap which automatically puts the actions into the helpList.
 
-	Note that you can only use ONE context here!"""
+	A context list is allowed, and for backward compatibility,
+	a single string context name also is allowed"""
 
 	# sorry for this complicated code.
 	# it's not more than converting a "documented" actionmap
@@ -122,10 +133,10 @@ class HelpableNumberActionMap(NumberActionMap, HelpableActionMap):
 	# added to the screen's "helpList", which will be picked up by
 	# the "HelpableScreen".
 	#
-	def __init__(self, parent, context, actions=None, prio=0, description=None):
+	def __init__(self, parent, contexts, actions=None, prio=0, description=None):
 		# Initialise NumberActionMap with empty context and actions
 		# so that the underlying ActionMap is only initialised with
 		# these once, via the HelpableActionMap.
 		#
 		NumberActionMap.__init__(self, [], {})
-		HelpableActionMap.__init__(self, parent, context, actions, prio, description)
+		HelpableActionMap.__init__(self, parent, contexts, actions, prio, description)


### PR DESCRIPTION
Allow HelpableActionMap and HelpableNumberActionMap to accept a list of contexts as well as a single context.  This makes it possible to convert ActionMap and NumberActionMap objects to helpable without changing their basic structure.  Single-context helpable ActionMaps are retained for backwards compatibility.

This change was held back to allow for an issue with the CSFD plugin to be corrected.  I am told by Ims21 that the issue has now been corrected.