### PR TITLE
idvb, servicedvb, epgcache - add flag dxNoEIT - thx

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -3157,6 +3157,13 @@ void eEPGCache::submitEventData(const std::vector<eServiceReferenceDVB>& service
 		serviceRef->getChannelID(chid);
 		chids.push_back(chid);
 		sids.push_back(serviceRef->getServiceID().get());
+
+		// disable EIT event parsing when using EPG_IMPORT
+		ePtr<eDVBService> service;
+		if (!eDVBDB::getInstance()->getService(*serviceRef, service) && service->useEIT())
+		{
+			service->m_flags |= eDVBService::dxNoEIT;
+		}
 	}
 	submitEventData(sids, chids, start, duration, title, short_summary, long_description, event_type, EPG_IMPORT);
 }

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -309,6 +309,7 @@ public:
 		dxHideVBI=512,
 		dxIsScrambledPMT=1024,
 		dxCenterDVBSubs=2048,
+		dxNoEIT=4096,
 	};
 
 	bool usePMT() const { return !(m_flags & dxNoDVB); }
@@ -316,6 +317,7 @@ public:
 	bool isDedicated3D() const { return m_flags & dxIsDedicated3D; }
 	bool doHideVBI() const { return m_flags & dxHideVBI; }
 	bool doCenterDVBSubs() const { return m_flags & dxCenterDVBSubs; }
+	bool useEIT() const { return !(m_flags & dxNoEIT); }
 
 	CAID_LIST m_ca;
 

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -1177,7 +1177,7 @@ void eDVBServicePlay::serviceEvent(int event)
 		updateEpgCacheNowNext();
 
 		/* default behaviour is to start an eit reader, and wait for now/next info, unless this is disabled */
-		if (eConfigManager::getConfigBoolValue("config.usage.show_eit_nownext", true))
+		if (m_dvb_service->useEIT() && eConfigManager::getConfigBoolValue("config.usage.show_eit_nownext", true))
 		{
 			ePtr<iDVBDemux> m_demux;
 			if (!m_service_handler.getDataDemux(m_demux))


### PR DESCRIPTION
 athoik/openpli

idvb: add new service flag dxNoEIT
When flag dxNoEIT is set we should not read EIT events from service but use EPG cache.

servicedvb: check if dxNoEIT flag before starting EIT reader
servicedvb will check against new dxNoEIT flag before start EIT reader.
When flag is set on service it will not start EIT reader.

epgcache: set dxNoEIT flag on service when using EPG Import
The dxNoEIT flag is enabled on a service when using EPG Import, so channels imported through EPG Import,  will not try to load again EIT using EIT reader.